### PR TITLE
feat: integrate event emitter for ranking updates in match and player services

### DIFF
--- a/apps/realtime-elo-ranker-server/src/api/match/match.service.ts
+++ b/apps/realtime-elo-ranker-server/src/api/match/match.service.ts
@@ -13,7 +13,6 @@ export class MatchService {
 
     @InjectRepository(Player)
     private readonly players: Repository<Player>,
-
     private eventEmitter: EventEmitter2,
   ) {}
 
@@ -21,8 +20,8 @@ export class MatchService {
     return this.matches.find();
   }
 
-  create(match: Match): Promise<Match> {
-    return this.save(match);
+  async create(match: Match): Promise<Match> {
+    return this.matches.save(match);
   }
 
   computeProbability = (rating1: number, rating2: number) => {
@@ -70,8 +69,12 @@ export class MatchService {
       draw,
     );
 
-    await this.players.save(winnerPlayer)
-    await this.players.save(loserPlayer)
+    await this.players.save(winnerPlayer).then(() => {
+      this.eventEmitter.emit('ranking.event', { type: 'RankingUpdate', player: winnerPlayer });
+    });
+    await this.players.save(loserPlayer).then(() => {
+        this.eventEmitter.emit('ranking.event', { type: 'RankingUpdate', player: loserPlayer });
+    });
     
     return { winner: winnerPlayer, loser: loserPlayer };
   }

--- a/apps/realtime-elo-ranker-server/src/api/player/player.service.ts
+++ b/apps/realtime-elo-ranker-server/src/api/player/player.service.ts
@@ -2,12 +2,14 @@ import { Injectable } from '@nestjs/common';
 import { Player } from 'src/entities/player.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 @Injectable()
 export class PlayerService {
   constructor(
     @InjectRepository(Player)
     private readonly players: Repository<Player>,
+    private eventEmitter: EventEmitter2,
   ) {}
 
   findOne(id: string): Promise<Player | null> {
@@ -23,8 +25,9 @@ export class PlayerService {
   }
 
   create(player: Player): Promise<Player> {
-    return this.players.save(player);
-  } 
+    this.eventEmitter.emit('ranking.event', { type: 'RankingUpdate', player: player });
+    return this.save(player);
+  }
 
   save(player: Player): Promise<Player> {
     return this.players.save(player);

--- a/apps/realtime-elo-ranker-server/src/app.module.ts
+++ b/apps/realtime-elo-ranker-server/src/app.module.ts
@@ -8,6 +8,7 @@ import { RankingController } from './api/ranking/ranking.controller';
 import { RankingModule } from './api/ranking/ranking.module';
 import { MatchModule } from './api/match/match.module';
 import { PlayerModule } from './api/player/player.module';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { PlayerModule } from './api/player/player.module';
       entities: [__dirname + '/**/*.entity{.ts,.js}'],
       synchronize: true,
     }),
+    EventEmitterModule.forRoot(),
     PlayerModule,
     RankingModule,
     MatchModule,


### PR DESCRIPTION
Ajout de l'EventEmitter2 dans le service PlayerService
Émission d'un événement ranking.event lors de la création d'un joueur.
Émission d'un événement ranking.event lors de la mise à jour du classement d'un joueur après un match.